### PR TITLE
Support transitive availability/visibility chains.

### DIFF
--- a/alloy/litmus.cpp
+++ b/alloy/litmus.cpp
@@ -71,7 +71,7 @@
 // must specify a scope" which, if violated, makes an execution trivially
 // unsatisfiable.
 //
-// "SLOC", "SSW", "SATISFIABLE", and "NOSOLUTION" are non-instruction
+// "SLOC", "SSW", "SATISFIABLE", "NOSOLUTION", and "NOCHAINS" are non-instruction
 // directives.
 //
 // "SLOC" takes two variable name strings and specifies that they access
@@ -92,6 +92,10 @@
 //
 // indicating that the program can be satisfied by a consistent execution
 // with no data races. Each line is an independent test.
+//
+// "NOCHAINS" can be put after SATISFIABLE or NOSOLUTION to indicate that
+// the test should run assuming the implementation does not support
+// availability and visibility chains with more than one element.
 //
 #include <algorithm>
 #include <sstream>
@@ -638,6 +642,13 @@ int main(int argc, char *argv[])
             line = line.substr(strlen("NOSOLUTION"));
             outreference << "NOSOLUTION\n";
         }
+
+        bool noChains = false;
+        if (line.find("NOCHAINS") != string::npos) {
+            noChains = true;
+            line = line.substr(line.find("NOCHAINS") + strlen("NOCHAINS"));
+        }
+
         outals << "pred gentest" << testnum << "[X:Exec] {\n";
         outals << "  #Exec = 1\n";
         outals << "  #E = " << numEvents << "\n";
@@ -651,6 +662,11 @@ int main(int argc, char *argv[])
         }
         outals << " : E {\n";
         outals << o.str();
+        if (noChains) {
+            outals << "    X.chains = stor[X.EV]\n";
+        } else {
+            outals << "    X.chains = (X.EV -> X.EV)\n";
+        }
         outals << "  }\n";
         outals << "  " << line << "\n";
         outals << "}\n";

--- a/alloy/tests/mp3transitive.test
+++ b/alloy/tests/mp3transitive.test
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Invocation 0 makes the write x=1 available to invocation 1.
+// Invocation 1 then does a bulk av operation with device scope.
+// This is enough to make x=1 visible to invocation 2.
+NEWWG
+NEWSG
+NEWTHREAD
+st.av.scopewg.sc0 x = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1 y = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1 y = 1
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1 z = 1
+ld.vis.scopedev.sc0 x
+SATISFIABLE consistent[X] && #dr=0
+NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)

--- a/alloy/tests/mp3transitive2.test
+++ b/alloy/tests/mp3transitive2.test
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Invocation 0 makes the write x=1 available to invocation 1.
+// Invocation 1 then does a bulk av operation with device scope.
+// Invocation 2 does a bulk vis op with device scope.
+// Invocation 3 does a bulk vis op with workgroup scope
+NEWWG
+NEWSG
+NEWTHREAD
+st.nonpriv.sc0 x = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1.semav y = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1 y = 1
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1.semvis z = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1 w = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1.semvis w = 1
+ld.nonpriv.sc0 x
+SATISFIABLE consistent[X] && #dr=0
+NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)

--- a/alloy/tests/mp3transitive3.test
+++ b/alloy/tests/mp3transitive3.test
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Invocation 0 makes the write x=1 available to invocation 1.
+// Invocation 1 then does a bulk av operation with device scope.
+// Invocation 2 does a bulk vis op with device scope.
+NEWWG
+NEWSG
+NEWTHREAD
+st.av.scopewg.sc0 x = 1
+cbar.acq.rel.scopewg.semsc0 0
+NEWSG
+NEWTHREAD
+cbar.acq.rel.scopewg.semsc0 0
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1 z = 1
+ld.vis.scopedev.sc0 x
+SATISFIABLE consistent[X] && #dr=0
+NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)

--- a/alloy/tests/mp3transitive4.test
+++ b/alloy/tests/mp3transitive4.test
@@ -1,0 +1,38 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Invocation 0 makes the write x=1 available to invocation 1.
+// Invocation 1 then does a bulk av operation with device scope.
+// Invocation 2->3 does happens-before
+// Invocation 3 does a bulk vis op with device scope
+// Invocation 4 does a bulk vis op with workgroup scope
+// The happens-before is sufficient even though it uses different
+// storage class semantics.
+NEWWG
+NEWSG
+NEWTHREAD
+st.nonpriv.sc0 x = 1
+st.atom.rel.scopewg.sc0.semsc0.semav y = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc0.semsc0 y = 1
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc1 z = 1
+st.atom.rel.scopedev.sc1.semsc1 v = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1.semvis v = 1
+st.atom.rel.scopewg.sc0.semsc0 w = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc0.semsc0.semvis w = 1
+ld.nonpriv.sc0 x
+SATISFIABLE consistent[X] && #dr=0
+NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)

--- a/alloy/tests/mp3transitivefail.test
+++ b/alloy/tests/mp3transitivefail.test
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Missing AVWG in invocation 0, so AVDEV in invocation 1 isn't
+// sufficient
+NEWWG
+NEWSG
+NEWTHREAD
+st.nonpriv.sc0 x = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1 y = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1 y = 1
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1.semvis z = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1 w = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1.semvis w = 1
+ld.nonpriv.sc0 x
+NOSOLUTION consistent[X] && #dr=0
+SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)

--- a/alloy/tests/mp3transitivefail2.test
+++ b/alloy/tests/mp3transitivefail2.test
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Missing VISWG in invocation 3, so VISDEV in invocation 2 isn't
+// sufficient
+NEWWG
+NEWSG
+NEWTHREAD
+st.nonpriv.sc0 x = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1.semav y = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1 y = 1
+st.atom.rel.scopedev.sc1.semsc0.semsc1.semav z = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc1.semsc0.semsc1.semvis z = 1
+st.atom.rel.scopewg.sc1.semsc0.semsc1 w = 1
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopewg.sc1.semsc0.semsc1 w = 1
+ld.nonpriv.sc0 x
+NOSOLUTION consistent[X] && #dr=0
+SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION NOCHAINS consistent[X] && #dr=0
+SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)


### PR DESCRIPTION
This corresponds to changes added to the Vulkan memory model appendix
released in the Vulkan 1.1.98 spec update. The chains are an optional
feature added to v3 of VK_KHR_vulkan_memory_model.

Transitive av/vis chains allow, for example, a single representative
invocation to make a whole workgroup's writes available outside of the
workgroup.