### PR TITLE
Loosen consistent[X] predicate

### DIFF
--- a/alloy/spirv.als
+++ b/alloy/spirv.als
@@ -30,6 +30,11 @@ fun stor[s : set E] : E -> E {
   s <: iden
 }
 
+// a chain of two or more hops through a relation
+fun twoplus[r : E -> E] : E -> E {
+  r.^r
+}
+
 // reduce a transitive relation to those immediately related
 fun imm[r : E -> E] : E -> E{
   r - (r.^r)
@@ -389,8 +394,8 @@ pred consistent[X:Exec] {
   // consistency: locord, rf, fr, asmo must not form cycles
   is_acyclic[X.locord + X.rf + X.fr + X.asmo]
 
-  // consistency: non-atomic reads must read-from a value that is still visible
-  X.rf . (stor[X.R-X.A]) in imm[(stor[X.W]) . (X.locord)]
+  // consistency: non-atomic cannot read-from a value that is shadowed by another write
+  no (X.rf . (stor[X.R - X.A])) & twoplus[stor[X.W] . (X.locord)]
 }
 
 pred racefree[X:Exec] {

--- a/alloy/tests/atomicsc.test
+++ b/alloy/tests/atomicsc.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0 y = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/atomwrongsc.test
+++ b/alloy/tests/atomwrongsc.test
@@ -16,4 +16,4 @@ ld.atom.acq.scopewg.sc0.semsc0 y = 1
 st.av.scopedev.sc0 z = 1
 SLOC x z
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION !consistent[X] || #dr>0
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/cbarinst.test
+++ b/alloy/tests/cbarinst.test
@@ -14,4 +14,4 @@ cbar.scopewg 1
 cbar.scopewg 2
 cbar.scopewg 3
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION !consistent[X] || #dr>0
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/fencefence.test
+++ b/alloy/tests/fencefence.test
@@ -14,4 +14,4 @@ ld.atom.scopewg.sc0 y = 1
 membar.acq.scopewg.semsc0
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/fencefence2.test
+++ b/alloy/tests/fencefence2.test
@@ -14,4 +14,4 @@ ld.atom.scopewg.sc1 y = 1
 membar.acq.scopewg.semsc0.semsc1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/fencefence3.test
+++ b/alloy/tests/fencefence3.test
@@ -20,4 +20,4 @@ ld.atom.scopewg.sc0 z = 1
 membar.acq.scopewg.semsc0
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/fencefencebroken.test
+++ b/alloy/tests/fencefencebroken.test
@@ -15,4 +15,4 @@ ld.atom.scopedev.sc0 y = 1
 membar.acq.scopewg.semsc0
 ld.vis.scopedev.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE #dr>0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/mp.test
+++ b/alloy/tests/mp.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0 y = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/mp3.test
+++ b/alloy/tests/mp3.test
@@ -16,4 +16,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0.semsc1 z = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/mp3acqrel.test
+++ b/alloy/tests/mp3acqrel.test
@@ -18,4 +18,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 y = 2
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0 && is_acyclic[X.asmo+X.rf]) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/mp3transitive.test
+++ b/alloy/tests/mp3transitive.test
@@ -20,6 +20,6 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc1.semsc0.semsc1 z = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0

--- a/alloy/tests/mp3transitive2.test
+++ b/alloy/tests/mp3transitive2.test
@@ -25,6 +25,7 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0.semsc1.semvis w = 1
 ld.nonpriv.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0
+

--- a/alloy/tests/mp3transitive3.test
+++ b/alloy/tests/mp3transitive3.test
@@ -20,6 +20,6 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc1.semsc0.semsc1 z = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0

--- a/alloy/tests/mp3transitive4.test
+++ b/alloy/tests/mp3transitive4.test
@@ -33,6 +33,6 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0.semvis w = 1
 ld.nonpriv.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0

--- a/alloy/tests/mp3transitivefail.test
+++ b/alloy/tests/mp3transitivefail.test
@@ -23,6 +23,6 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0.semsc1.semvis w = 1
 ld.nonpriv.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0

--- a/alloy/tests/mp3transitivefail2.test
+++ b/alloy/tests/mp3transitivefail2.test
@@ -23,6 +23,7 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0.semsc1 w = 1
 ld.nonpriv.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0
 NOSOLUTION NOCHAINS consistent[X] && #dr=0
-SATISFIABLE NOCHAINS (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE NOCHAINS consistent[X] && #dr>0
+

--- a/alloy/tests/mpsc1.test
+++ b/alloy/tests/mpsc1.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc1 y = 1
 ld.vis.scopedev.sc1 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohandatom.test
+++ b/alloy/tests/noncohandatom.test
@@ -10,4 +10,4 @@ st.nonpriv.sc0 y = 1
 rmw.scopewg.sc0 y = 1 2
 ld.sc0 y = 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmp.test
+++ b/alloy/tests/noncohmp.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.acq.semvis.scopewg.sc0.semsc0 y = 1
 ld.nonpriv.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmp2.test
+++ b/alloy/tests/noncohmp2.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.semvis.scopewg.sc0.semsc0 y = 1
 ld.nonpriv.sc0 x = 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmp3.test
+++ b/alloy/tests/noncohmp3.test
@@ -14,4 +14,4 @@ ld.atom.acq.scopewg.sc0.semsc0 y = 1
 ld.vis.scopedev.sc0 x = 2
 ld.nonpriv.sc0 x = 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmpbar.test
+++ b/alloy/tests/noncohmpbar.test
@@ -15,4 +15,4 @@ ld.atom.scopedev.sc0 y = 1
 membar.acq.scopedev.semvis.semsc0
 ld.nonpriv.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmpbarsg.test
+++ b/alloy/tests/noncohmpbarsg.test
@@ -12,4 +12,4 @@ NEWTHREAD
 cbar.acq.rel.scopesg.semvis.semav.semsc0 0
 ld.nonpriv.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/noncohmpfail.test
+++ b/alloy/tests/noncohmpfail.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0 z = 1
 ld.vis.scopedev.sc0 x = 1
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/noncohmpfail2.test
+++ b/alloy/tests/noncohmpfail2.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.semvis.sc0.semsc0 z = 1
 ld.nonpriv.sc0 x = 1
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/noncohwar.test
+++ b/alloy/tests/noncohwar.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.semvis.scopewg.sc0.semsc0 y = 1
 st.nonpriv.sc0 x = 1
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT!=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/privmp.test
+++ b/alloy/tests/privmp.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.semvis.scopewg.sc0.semsc0 y = 1
 ld.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/privpo.test
+++ b/alloy/tests/privpo.test
@@ -11,4 +11,4 @@ st.sc0 x = 1
 ld.sc0 x = 1
 st.nonpriv.sc0 x = 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/privwar.test
+++ b/alloy/tests/privwar.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.semvis.scopewg.sc0.semsc0 y = 1
 st.sc0 x = 1
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/qfmp.test
+++ b/alloy/tests/qfmp.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopeqf.sc0.semsc0 y = 1
 ld.vis.scopeqf.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/qfmpfail.test
+++ b/alloy/tests/qfmpfail.test
@@ -16,4 +16,4 @@ NEWTHREAD
 ld.atom.acq.scopeqf.sc0.semsc0 y = 1
 ld.vis.scopeqf.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/qfmpscopedev.test
+++ b/alloy/tests/qfmpscopedev.test
@@ -15,4 +15,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 y = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/releaseseq3.test
+++ b/alloy/tests/releaseseq3.test
@@ -18,4 +18,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 y = 2
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0 && is_acyclic[X.asmo+X.rf]) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/releaseseq4.test
+++ b/alloy/tests/releaseseq4.test
@@ -19,4 +19,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 y = 2
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0 && is_acyclic[X.asmo+X.rf]) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/samethread.test
+++ b/alloy/tests/samethread.test
@@ -15,4 +15,4 @@ ld.atom.acq.scopewg.sc0.semsc0 y = 1
 st.av.scopedev.sc0 x = 2
 st.atom.rel.scopewg.sc0.semsc0 z = 1
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION !consistent[X] || #dr>0
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/scopeaccum.test
+++ b/alloy/tests/scopeaccum.test
@@ -17,4 +17,4 @@ NEWTHREAD
 cbar.scopedev.semsc0.rel.acq 2
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw0.test
+++ b/alloy/tests/ssw0.test
@@ -16,4 +16,4 @@ ld.sc0 x
 SSW 0 1
 SSW 1 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw1.test
+++ b/alloy/tests/ssw1.test
@@ -17,4 +17,4 @@ SSW 0 1
 SSW 1 2
 SLOC x y
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw2.test
+++ b/alloy/tests/ssw2.test
@@ -12,4 +12,4 @@ NEWTHREAD 1
 ld.sc0 x
 SSW 0 1
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/ssw3.test
+++ b/alloy/tests/ssw3.test
@@ -12,4 +12,4 @@ NEWTHREAD 1
 ld.vis.scopedev.sc0 x
 SSW 0 1
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw4.test
+++ b/alloy/tests/ssw4.test
@@ -13,4 +13,4 @@ ld.vis.scopedev.sc1 y
 SSW 0 1
 SLOC x y
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/ssw5.test
+++ b/alloy/tests/ssw5.test
@@ -20,4 +20,4 @@ ld.sc0 x
 SSW 0 1
 SSW 1 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw6.test
+++ b/alloy/tests/ssw6.test
@@ -12,4 +12,4 @@ NEWTHREAD 1
 st.sc0 x = 1
 SSW 0 1
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=1) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw7.test
+++ b/alloy/tests/ssw7.test
@@ -16,4 +16,4 @@ st.sc0 x = 1
 SSW 0 1
 SSW 1 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=2) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/ssw8.test
+++ b/alloy/tests/ssw8.test
@@ -15,4 +15,4 @@ membar.acq.semvis.scopeqf.semsc0
 ld.nonpriv.sc0 x
 SSW 0 1
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test0.test
+++ b/alloy/tests/test0.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0.semsc1 c = 1
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE !consistent[X] || #dr>0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test1.test
+++ b/alloy/tests/test1.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc1 c = 1
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE !consistent[X] || #dr>0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test10.test
+++ b/alloy/tests/test10.test
@@ -22,4 +22,4 @@ NEWTHREAD
 cbar.acq.rel.scopewg.semsc0 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test11.test
+++ b/alloy/tests/test11.test
@@ -14,4 +14,4 @@ cbar.acq.rel.scopewg.semsc0.semsc1 0
 st.av.scopedev.sc1 b = 1
 SLOC a b
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT!=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test12.test
+++ b/alloy/tests/test12.test
@@ -15,4 +15,4 @@ cbar.scopewg 0
 membar.acq.scopewg.semsc0
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test13.test
+++ b/alloy/tests/test13.test
@@ -20,4 +20,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 c = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test14.test
+++ b/alloy/tests/test14.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc1.semsc0 b = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test16.test
+++ b/alloy/tests/test16.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.scopewg.sc0 a = 1
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test17.test
+++ b/alloy/tests/test17.test
@@ -12,4 +12,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0 a = 1
 ld.vis.scopewg.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test18.test
+++ b/alloy/tests/test18.test
@@ -13,4 +13,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 a = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test19.test
+++ b/alloy/tests/test19.test
@@ -15,4 +15,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 a = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test2.test
+++ b/alloy/tests/test2.test
@@ -18,4 +18,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc1.semsc1 c = 1
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE !consistent[X] || #dr>0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test20.test
+++ b/alloy/tests/test20.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 b = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test21.test
+++ b/alloy/tests/test21.test
@@ -14,4 +14,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 y = 1
 ld.vis.scopewg.sc0 x
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test3.test
+++ b/alloy/tests/test3.test
@@ -19,4 +19,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 c = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test4.test
+++ b/alloy/tests/test4.test
@@ -23,4 +23,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0 d = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test5.test
+++ b/alloy/tests/test5.test
@@ -22,4 +22,4 @@ NEWTHREAD
 ld.atom.acq.scopewg.sc0.semsc0 d = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test6.test
+++ b/alloy/tests/test6.test
@@ -22,4 +22,4 @@ NEWTHREAD
 cbar.acq.rel.scopewg.semsc0 2
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test7.test
+++ b/alloy/tests/test7.test
@@ -22,4 +22,4 @@ NEWTHREAD
 cbar.acq.rel.scopewg.semsc0 2
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
-SATISFIABLE (#RFINIT=0) && (!consistent[X] || #dr>0)
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/test9.test
+++ b/alloy/tests/test9.test
@@ -18,4 +18,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc1.semsc0 b = 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (#RFINIT=0) && (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/waw.test
+++ b/alloy/tests/waw.test
@@ -20,4 +20,4 @@ NEWTHREAD
 ld.atom.acq.scopedev.sc0.semsc0 z = 1
 ld.vis.scopedev.sc0 x = 2
 SATISFIABLE consistent[X] && #dr=0
-NOSOLUTION (!consistent[X] || #dr>0)
+NOSOLUTION consistent[X] && #dr>0


### PR DESCRIPTION
Make the "consistent" predicate accept reads that are not in location order, but still forbid reads from locations that are shadowed by another write.

Also simplify tests to have a simpler and more principled interpretation. A typical failing data race test has a satisfiable solution that is consistent and has a data race, and no solution that is consistent and race-free. A typical pass test simply has the predicates reversed: there is a consistent data-race free solution, and no consistent solution with a data race.

This version of the PR is incomplete, as there are three tests that need further attention: mp3acqrel, releaseseq3, and releaseseq4. They all pass but could probably be refined.

Fixes #27