### PR TITLE
Align avvis semantics with the specification

### DIFF
--- a/alloy/tests/mpinscope1.test
+++ b/alloy/tests/mpinscope1.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopedev.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+ld.atom.acq.scopedev.sc0.semsc0 x = 0
+NOSOLUTION consistent[X]

--- a/alloy/tests/mpinscope2.test
+++ b/alloy/tests/mpinscope2.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopedev.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc1 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc1 y = 1
+ld.atom.acq.scopedev.sc0.semsc0 x = 0
+SATISFIABLE consistent[X] && #dr=0

--- a/alloy/tests/mpinscope3.test
+++ b/alloy/tests/mpinscope3.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopedev.sc0.semsc0.semav x = 1
+st.atom.rel.scopedev.sc0.semsc1 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc1 y = 1
+ld.atom.acq.scopedev.sc0.semsc0.semvis x = 0
+SATISFIABLE consistent[X] && #dr=0

--- a/alloy/tests/mpinscope4.test
+++ b/alloy/tests/mpinscope4.test
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopedev.sc0.semsc0 x = 1
+membar.rel.scopedev.semsc0.semav
+st.atom.rel.scopedev.sc0.semsc1 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc1 y = 1
+membar.acq.scopedev.semsc0.semvis
+ld.atom.acq.scopedev.sc0.semsc0 x = 0
+NOSOLUTION consistent[X]

--- a/alloy/tests/mpinscope5.test
+++ b/alloy/tests/mpinscope5.test
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+membar.rel.scopedev.semsc0.semav
+st.atom.rel.scopedev.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc1 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc1 y = 1
+ld.atom.acq.scopedev.sc0.semsc0 x = 0
+membar.acq.scopedev.semsc0.semvis
+SATISFIABLE consistent[X] && #dr=0

--- a/alloy/tests/mpnotinscope1.test
+++ b/alloy/tests/mpnotinscope1.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopewg.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc0.semav y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0.semvis y = 1
+ld.atom.acq.scopewg.sc0.semsc0 x = 0
+NOSOLUTION consistent[X]

--- a/alloy/tests/mpnotinscope2.test
+++ b/alloy/tests/mpnotinscope2.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopewg.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+ld.atom.acq.scopewg.sc0.semsc0 x = 0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/mpnotinscope3.test
+++ b/alloy/tests/mpnotinscope3.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopewg.sc0.semsc0.semav x = 1
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+ld.atom.acq.scopewg.sc0.semsc0.semvis x = 0
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/mpnotinscope4.test
+++ b/alloy/tests/mpnotinscope4.test
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopewg.sc0.semsc0 x = 1
+membar.rel.scopedev.semsc0.semav
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+membar.acq.scopedev.semsc0.semvis
+ld.atom.acq.scopewg.sc0.semsc0 x = 0
+NOSOLUTION consistent[X]

--- a/alloy/tests/mpnotinscope5.test
+++ b/alloy/tests/mpnotinscope5.test
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+membar.rel.scopewg.semsc0.semav
+st.atom.rel.scopewg.sc0.semsc0 x = 1
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+ld.atom.acq.scopewg.sc0.semsc0 x = 0
+membar.acq.scopewg.semsc0.semvis
+SATISFIABLE consistent[X] && #dr>0

--- a/alloy/tests/mpnotinscope6.test
+++ b/alloy/tests/mpnotinscope6.test
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.atom.rel.scopewg.sc0.semsc0 x = 1
+membar.rel.scopewg.semsc0.semav
+st.atom.rel.scopedev.sc0.semsc0 y = 1
+NEWWG
+NEWSG
+NEWTHREAD
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+membar.acq.scopewg.semsc0.semvis
+ld.atom.acq.scopewg.sc0.semsc0 x = 0
+SATISFIABLE consistent[X] && #dr>0


### PR DESCRIPTION
This commit updates the definition of avvis semantics to align with the Vulkan specification. The bidirectional avvisinc relation is now replaced with a unidirectional one. For availability semantics, the avvisinc relation is generated for operations ordered before the current operation but not for the operation itself. For visibility semantics, the definition is symmetric.

This commit changes the behavior of test mpinscope3, mpnotinscope3, and mpnotinscope6 from safe to unsafe under the memory model.