### PR TITLE
Set Alloy integer bitwidth in generated tests

### DIFF
--- a/alloy/litmus.cpp
+++ b/alloy/litmus.cpp
@@ -107,6 +107,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cassert>
+#include <cmath>
 
 using namespace std;
 
@@ -341,6 +342,7 @@ int main(int argc, char *argv[])
 
     int threadnum = 0;
     int numEvents = 0;
+    int bitwidth = 0;
 
     vector<string> sswInputs;
     vector<string> slocInputs;
@@ -480,6 +482,7 @@ int main(int argc, char *argv[])
     }
 
     numEvents = instnum+1;
+    bitwidth = ceil(log2(numEvents * numEvents + 1) + 1);
 
     stringstream ssw;
     for (size_t i = 0; i < sswInputs.size(); ++i) {
@@ -670,7 +673,10 @@ int main(int argc, char *argv[])
         outals << "  }\n";
         outals << "  " << line << "\n";
         outals << "}\n";
-        outals << "run gentest" << testnum << " for " << numEvents << "\n";
+        outals << "run gentest" << testnum << " ";
+        outals << "for exactly 1 spirv/Exec, ";
+        outals << "exactly " << numEvents << " spirv/E, ";
+        outals << bitwidth << " int" << "\n";
         testnum++;
     }
 

--- a/alloy/tests/races.test
+++ b/alloy/tests/races.test
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NEWWG
+NEWSG
+NEWTHREAD
+st.sc0 x = 1
+st.sc0 x = 2
+NEWWG
+NEWSG
+NEWTHREAD
+st.sc0 x = 3
+st.sc0 x = 4
+SATISFIABLE consistent[X] && #dr>0


### PR DESCRIPTION
By default, Alloy uses signed 4-bit integers (range from -8 to 7). This can lead to an integer overflow if a relation contains more than 7 edges. In the races.test, this causes a negative data race count 'SATISFIABLE consistent[X] && #dr<0'.

This commit updates litmus.cpp to explicitly set a bitwidth large enough to represent all event pairs in a given program.