### PR TITLE
Warning if cbar synchronizes across workgroups

### DIFF
--- a/alloy/tests/scopeaccum.test
+++ b/alloy/tests/scopeaccum.test
@@ -10,11 +10,11 @@ cbar.scopewg.semsc0.rel.acq 1
 NEWSG
 NEWTHREAD
 cbar.scopewg.semsc0.rel.acq 1
-cbar.scopedev.semsc0.rel.acq 2
+st.atom.rel.scopedev.sc0.semsc0 y = 1
 NEWWG
 NEWSG
 NEWTHREAD
-cbar.scopedev.semsc0.rel.acq 2
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
 ld.vis.scopedev.sc0 x
 SATISFIABLE consistent[X] && #dr=0
 NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test6.test
+++ b/alloy/tests/test6.test
@@ -11,15 +11,15 @@ cbar.acq.rel.scopewg.semsc0 0
 NEWSG
 NEWTHREAD
 cbar.acq.rel.scopewg.semsc0 0
-cbar.acq.rel.scopedev.semsc0 1
+st.atom.rel.scopedev.sc0.semsc0 y = 1
 NEWWG
 NEWSG
 NEWTHREAD
-cbar.acq.rel.scopedev.semsc0 1
-cbar.acq.rel.scopewg.semsc0 2
+ld.atom.acq.scopedev.sc0.semsc0 y = 1
+cbar.acq.rel.scopewg.semsc0 1
 NEWSG
 NEWTHREAD
-cbar.acq.rel.scopewg.semsc0 2
+cbar.acq.rel.scopewg.semsc0 1
 ld.vis.scopedev.sc0 a
 SATISFIABLE consistent[X] && #dr=0
 NOSOLUTION consistent[X] && #dr>0

--- a/alloy/tests/test7.test
+++ b/alloy/tests/test7.test
@@ -11,15 +11,15 @@ cbar.acq.rel.scopewg.semsc0 0
 NEWSG
 NEWTHREAD
 cbar.acq.rel.scopewg.semsc0 0
-cbar.acq.rel.scopedev.semsc1 1
+st.atom.rel.scopedev.sc0.semsc1 y = 1
 NEWWG
 NEWSG
 NEWTHREAD
-cbar.acq.rel.scopedev.semsc1 1
-cbar.acq.rel.scopewg.semsc0 2
+ld.atom.acq.scopedev.sc0.semsc1 y = 1
+cbar.acq.rel.scopewg.semsc0 1
 NEWSG
 NEWTHREAD
-cbar.acq.rel.scopewg.semsc0 2
+cbar.acq.rel.scopewg.semsc0 1
 ld.vis.scopedev.sc0 a
 NOSOLUTION consistent[X] && #dr=0
 SATISFIABLE consistent[X] && #dr>0


### PR DESCRIPTION
Print a warning if control barriers with the same instance id are used across different workgroups. Update existing tests with such barriers to use a smaller scope.